### PR TITLE
chore: npm-publish: replace "npm install --legacy-peer-deps" with "npm ci"

### DIFF
--- a/scripts/ci-npm-publish.sh
+++ b/scripts/ci-npm-publish.sh
@@ -36,10 +36,7 @@ to_publish=0
 if [[ -z "$package_version_remote" ]]; then
   # package does not exist at the remote registry
   echo "Publishing npm package from $source_folder"
-  # NOTE-zw: here we allow broken peer dependencies by intention.
-  # This is not a good practice for production, but we do have some packages that have broken peer dependencies.
-  # As the local test is required anyway before commiting the code for final assembly, we can allow this here.
-  npm --no-color install --legacy-peer-deps
+  npm --no-color ci
   npm --no-color run build
   to_publish=1
 fi


### PR DESCRIPTION
Motivation:
* Self-Service email-service npm package fails if `--legacy-peer-deps` is used
* `npm install` does not install the same versions as package.json in practice: virtually always we use `^#.#.#` in `package.json` - using `npm install` will install the latest minor version while `npm ci` will respect the lock file