### PR TITLE
feat: Enable PR environments

### DIFF
--- a/scripts/ci-deploy.sh
+++ b/scripts/ci-deploy.sh
@@ -47,6 +47,7 @@ else
   IS_PR_ENV_BUILD="false"
 fi
 
+
 # check that each module contains something deployable
 for module in "${MODULES[@]}"; do
   pushd "${module}"

--- a/scripts/ci-deploy.sh
+++ b/scripts/ci-deploy.sh
@@ -38,6 +38,15 @@ fi
 
 MODULES=(${INFRASTRUCTURE_FOLDERS//,/ })
 
+# PR Environment condition
+DEPLOY_PR_ENV_FLAG="$(cat /tmp/is_pr_env_deploy_flag 2>/dev/null)"
+PR_NUMBER="$(cat /tmp/pr_number 2>/dev/null)"
+if [[ ${DEPLOY_PR_ENV_FLAG} == "1" ]] && [[ ${PR_NUMBER} =~ ^[0-9]+$ ]]; then
+  IS_PR_ENV_BUILD="true"
+else
+  IS_PR_ENV_BUILD="false"
+fi
+
 # check that each module contains something deployable
 for module in "${MODULES[@]}"; do
   pushd "${module}"
@@ -65,7 +74,13 @@ for module in "${MODULES[@]}"; do
     if [[ -f "requirements.txt" ]]; then
       pip install -r requirements.txt
     fi
-    ansible-playbook -e env="$ENV" playbook.yml
+
+    if [[ "$IS_PR_ENV_BUILD" != "true" ]]; then
+      ansible-playbook -e env="$ENV" playbook.yml
+    else
+      ansible-playbook -e env="$ENV" -e is_pr_env_build="$IS_PR_ENV_BUILD" -e pr_number="$PR_NUMBER" playbook.yml
+    fi
+    
   fi
 
   popd

--- a/scripts/ci-init.sh
+++ b/scripts/ci-init.sh
@@ -45,7 +45,7 @@ else
 fi
 
 # Check if we should deploy PR environment
-if [[ ${FORCE_DEPLOY_PR_ENVIRONMENT} =~ ^[0-9]+$ ]]; then
+if [[ ${ENABLE_PR_ENVIRONMENTS} == "true" ]] && [[ ${FORCE_DEPLOY_PR_ENVIRONMENT} =~ ^[0-9]+$ ]]; then
    DEPLOYING="Will deploy (because: FORCE_DEPLOY_PR_ENVIRONMENT)"
    echo "1" > /tmp/is_deploy_flag
    echo "1" > /tmp/is_pr_env_deploy_flag


### PR DESCRIPTION
Relates to 
* https://github.com/alloy-ch/rcplus-alloy-infrastructure-cockpit/pull/21
* https://github.com/alloy-ch/rcplus-alloy-cockpit-frontend/pull/600

Will deploy† PR environment if:
* If PR has label `pr-environment`
* If env-variable ENABLE_PR_ENVIRONMENTS is `true` (set it in buildspec.yml)
* If build was triggered by GitHub PR update (`CODEBUILD_WEBHOOK_TRIGGER` matches `pr/*`)
* (and unless not already deploying normally)

_OR_

* `FORCE_DEPLOY_PR_ENVIRONMENT` is set to a number and `ENABLE_PR_ENVIRONMENTS` is `true`

† by adding parameters to Ansible, meaning the repository Ansible playbook must understand and support the params.