### PR TITLE
feat: ci-notify-slack.sh: add option "only-deploy-failures"

### DIFF
--- a/scripts/ci-notify-slack.sh
+++ b/scripts/ci-notify-slack.sh
@@ -26,6 +26,13 @@ else
     style="danger"
 fi
 
+if [[ $1 == "only-deploy-failures" ]]; then
+  if [[ ${noun} != 'Deploy' ]] || [[ ${adjective} != "failed" ]]; then
+    echo 'Will not notify slack since "only-deploy-failures" is set and the deployment did not fail';
+    exit 0;
+  fi
+fi
+
 
 # remove the deploy flags to avoid confusing the next deployment
 rm -f /tmp/is_deploy_flag


### PR DESCRIPTION
This allows a repository to change the Slack notification logic to only notify slack if deployment failed. This is useful for ops-ci-codebuild which deploys every night